### PR TITLE
Remove deprecated gemspec information

### DIFF
--- a/andand.gemspec
+++ b/andand.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
 "License.txt",
 "Manifest.txt",
 "README.textile",
-"README.txt",
 "Rakefile",
 "config/hoe.rb",
 "config/requirements.rb",


### PR DESCRIPTION
Deprecated as of Rubygems v1.7.0

When I update gem to v > 1.7.0, I get a warning that looks like:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01.
Gem::Specification#has_rdoc= called from ~/.rvm/gems/ree-1.8.7-head@global/bundler/gems/andand-0a40be8a9c9d/andand.gemspec:9
```

This patch removes this bug by deleting the offending line.
