### PR TITLE
Avoid using a global BlankSlate class

### DIFF
--- a/lib/andand.rb
+++ b/lib/andand.rb
@@ -97,9 +97,9 @@ end
 class Object
   include AndAnd::ObjectGoodies
 end
-  
-unless Module.constants.map { |c| c.to_s }.include?('BlankSlate')
- if Module.constants.map { |c| c.to_s }.include?('BasicObject')
+
+unless defined?(::AndAnd::BlankSlate)
+  if defined?(::BasicObject)
     module AndAnd
       class BlankSlate < BasicObject
       end

--- a/test/andand_spec.rb
+++ b/test/andand_spec.rb
@@ -112,6 +112,16 @@ describe AndAnd, "Mixing Me with AndAnd" do
   end
 end
 
+describe 'AndAnd::BlankSlate' do
+  it 'should not respond to Object methods' do
+    nil.andand.to_s.should == nil
+  end
+
+  it 'should not be based on a global BlankSlate object' do
+    nil.andand.respond_to?(:method_on_global_blank_slate).should be_false
+  end
+end
+
 class Foo
   def frobbish
     'fnord'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,10 @@
+class BlankSlate
+  # A global BlankSlate object. This is bad, because it inherits from Object
+  # and offers more methods than AndAnd::BlankSlate should offer.
+  # For example, ActiveSupport creates a global BlankSlate class.
+  def method_on_global_blank_slate
+  end
+end
+
 require 'test/unit'
 require File.dirname(__FILE__) + '/../lib/andand'


### PR DESCRIPTION
This caused some trouble when migrating a Rails 2 application to Ruby 1.9:

``` ruby
1.9.3p385 :008 > nil.andand.to_s
 => "#<AndAnd::MockReturningMe:0x0000001ed54ad0>" 
```

While it is fine on a plain Ruby 1.9.3 IRB (`nil.andand.to_s` is `nil`, as it should be), it fails when there is a (global) `BlankSlate` class -- which Rails 2's `ActiveSupport` defines, for example.
I'm not sure if this happens only on Rails 2 + Ruby 1.9, but I'm pretty sure we never want to use a global `BlankSlate` class, so we're no longer doing that. :)

The pull request also includes some changes to make specs run on Ruby 1.9, and makes a spec more robust which expects an error to happen.

Specs are passing for Ruby 1.8.7, REE and Ruby 1.9.3: https://travis-ci.org/makandra/andand
