### PR TITLE
Prevent undef of object_id.

### DIFF
--- a/lib/andand.rb
+++ b/lib/andand.rb
@@ -108,7 +108,7 @@ unless defined?(::AndAnd::BlankSlate)
     module AndAnd
       class BlankSlate
         def self.wipe
-          instance_methods.reject { |m| m =~ /^__/ }.each { |m| undef_method m }
+          instance_methods.reject { |m| m =~ /^__|object_id/ }.each { |m| undef_method m }
         end
         def initialize
           BlankSlate.wipe


### PR DESCRIPTION
Adding object_id to regex of methods that should not be undefined.
Without this Ruby gives a warning: undefining 'object_id' may cause
serious problems.

Happy to make any corrections needed.

Mike
