### PR TITLE
Properly check for Object#tap existence

### DIFF
--- a/lib/andand.rb
+++ b/lib/andand.rb
@@ -67,7 +67,7 @@ module AndAnd
       end
     end
     
-    unless Object.instance_methods.include?('tap')
+    unless Object.instance_methods.map(&:to_sym).include?(:tap)
       alias :tap :me
     end
     


### PR DESCRIPTION
As pointed out in #10, the check for `Object#tap` is broken since Ruby 1.9. This PR fixes it for Ruby 1.8 and 1.9+.
